### PR TITLE
fix for unit tests on this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you're looking to raise an issue with this module, please create a new issue 
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | v6.2.0 |
+| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | v6.3.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 
 module "s3-bucket" {
   count  = var.existing_bucket_name == "" ? 1 : 0
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.2.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.3.0"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication


### PR DESCRIPTION
after looking at the dependabot unit test failed i looked into the issue and found that the s3 module was still referencing v6.2.0 this pr updates this reference to v6.3.0 