### PR TITLE
AWS Provider 5.0 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.idea
 .terraform/
 coverage/
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .idea
 .terraform/
+.terraform.lock.hcl
 coverage/
 venv/
 env/
@@ -9,3 +10,4 @@ env/
 *.code-workspace
 *.sha256
 terraform.tfstate
+terraform.tfstate.backup

--- a/README.md
+++ b/README.md
@@ -42,19 +42,20 @@ If you're looking to raise an issue with this module, please create a new issue 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | ~> 3.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | v6.4.0 |
+| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | v7.0.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 
 module "s3-bucket" {
   count  = var.existing_bucket_name == "" ? 1 : 0
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.4.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
 
   providers = {
     aws.bucket-replication = aws.bucket-replication

--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -1,8 +1,12 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
+    }
+    http = {
+      source = "hashicorp/http"
+      version = "~> 3.3"
     }
   }
   required_version = ">= 1.0.1"

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,12 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.0"
+      version = "~> 5.0"
       source  = "hashicorp/aws"
+    }
+    http = {
+      source = "hashicorp/http"
+      version = "~> 3.3"
     }
   }
   required_version = ">= 1.0.1"


### PR DESCRIPTION
Bumps version constraint to ~> 5.0.
Adds `http` provider.
Related to https://github.com/ministryofjustice/modernisation-platform/issues/4173