### PR TITLE
Terraform Static Analysis fixes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 
-  permissions: {}
+permissions: {}
 
 jobs:
   docs:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,8 +5,13 @@ on:
     branches:
       - main
 
+  permissions: {}
+
 jobs:
   docs:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -52,3 +52,4 @@ jobs:
         scan_type: full
         tfsec_exclude: AWS089, AWS099, AWS009, AWS097, AWS018
         checkov_exclude: CKV_GIT_1
+        tflint_exclude: terraform_unused_declarations

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ module "s3-bucket" {
   providers = {
     aws.bucket-replication = aws.bucket-replication
   }
-  bucket_name         = "${var.application_name}-ssm-patching-logs"
+  bucket_prefix         = "${var.application_name}-ssm-patching-logs"
   bucket_policy       = [data.aws_iam_policy_document.bucket_policy.json]
   replication_enabled = false
   versioning_enabled  = true

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ module "s3-bucket" {
   providers = {
     aws.bucket-replication = aws.bucket-replication
   }
-  bucket_prefix         = "${var.application_name}-ssm-patching-logs"
+  bucket_prefix       = "${var.application_name}-ssm-patching-logs"
   bucket_policy       = [data.aws_iam_policy_document.bucket_policy.json]
   replication_enabled = false
   versioning_enabled  = true


### PR DESCRIPTION
* Added tflint exclusion to keep locals consistent across repositories
* Scoped permissions for documentation action
* Amended module to use `bucket_prefix` instead of `bucket_name` for logs so that we don't run into issues with name clashes