### PR TITLE
Resolve provider warning and bucket name size

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ module "s3-bucket" {
   providers = {
     aws.bucket-replication = aws.bucket-replication
   }
-  bucket_prefix       = "${var.application_name}-ssm-patching-logs"
+  bucket_prefix       = "${var.application_name}-ssm"
   bucket_policy       = [data.aws_iam_policy_document.bucket_policy.json]
   replication_enabled = false
   versioning_enabled  = true

--- a/versions.tf
+++ b/versions.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
-      source  = "hashicorp/aws"
+      version               = "~> 5.0"
+      source                = "hashicorp/aws"
       configuration_aliases = [aws.bucket-replication]
     }
     http = {
-      source = "hashicorp/http"
+      source  = "hashicorp/http"
       version = "~> 3.3"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -3,6 +3,7 @@ terraform {
     aws = {
       version = "~> 5.0"
       source  = "hashicorp/aws"
+      configuration_aliases = [aws.bucket-replication, aws.core-vpc, aws.core-network-services]
     }
     http = {
       source = "hashicorp/http"

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
     aws = {
       version = "~> 5.0"
       source  = "hashicorp/aws"
-      configuration_aliases = [aws.bucket-replication, aws.core-vpc, aws.core-network-services]
+      configuration_aliases = [aws.bucket-replication]
     }
     http = {
       source = "hashicorp/http"


### PR DESCRIPTION
Bucket fails to create due to the `bucket_prefix` size being too long hence shortened it.
```
╷
│ Error: expected length of bucket_prefix to be in the range (0 - 37), got hmpps-domain-services-ssm-patching-logs
│ 
│   with module.test[0].module.s3-bucket[0].aws_s3_bucket.default,
│   on .terraform/modules/test.s3-bucket/main.tf line 15, in resource "aws_s3_bucket" "default":
│   15:   bucket_prefix = var.bucket_prefix
│ 
╵
```

Cleared the warning by defining  `configuration_aliases`  although don't really understand this code too well to be honest!

```
╷
│ Warning: Reference to undefined provider
│ 
│   on patch.tf line 30, in module "test":
│   30:     aws.bucket-replication = aws
│ 
│ There is no explicit declaration for local provider name
│ "aws.bucket-replication" in module.test, so Terraform is assuming you mean
│ to pass a configuration for "hashicorp/aws".
│ 
│ If you also control the child module, add a required_providers entry named
│ "aws.bucket-replication" with the source address "hashicorp/aws".
╵
```