### PR TITLE
Support multiple schedules per environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ If you're looking to raise an issue with this module, please create a new issue 
 | <a name="input_patch_schedule"></a> [patch\_schedule](#input\_patch\_schedule) | Crontab on when to run the automation script. | `string` | `"cron(00 22 ? * MON *)"` | no |
 | <a name="input_patch_tag"></a> [patch\_tag](#input\_patch\_tag) | Defaults as yes, but can be customised if pre existing tags and values want to be used | `string` | `"Yes"` | no |
 | <a name="input_rejected_patches"></a> [rejected\_patches](#input\_rejected\_patches) | List of patches to be rejected | `list(string)` | `[]` | no |
-| <a name="input_suffix"></a> [suffix](#input\_suffix) | When creating multiple patch schedules per environment, a suffix can be used to differentiate resources | `string` | `null` | no |
+| <a name="input_suffix"></a> [suffix](#input\_suffix) | When creating multiple patch schedules per environment, a suffix can be used to differentiate resources | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Common tags to be used by all resources | `map(string)` | n/a | yes |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ If you're looking to raise an issue with this module, please create a new issue 
 | <a name="input_patch_schedule"></a> [patch\_schedule](#input\_patch\_schedule) | Crontab on when to run the automation script. | `string` | `"cron(00 22 ? * MON *)"` | no |
 | <a name="input_patch_tag"></a> [patch\_tag](#input\_patch\_tag) | Defaults as yes, but can be customised if pre existing tags and values want to be used | `string` | `"Yes"` | no |
 | <a name="input_rejected_patches"></a> [rejected\_patches](#input\_rejected\_patches) | List of patches to be rejected | `list(string)` | `[]` | no |
+| <a name="input_suffix"></a> [suffix](#input\_suffix) | When creating multiple patch schedules per environment, a suffix can be used to differentiate resources | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Common tags to be used by all resources | `map(string)` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ module "s3-bucket" {
   providers = {
     aws.bucket-replication = aws.bucket-replication
   }
-  bucket_prefix       = "${var.application_name}-ssm"
+  bucket_prefix       = "${var.application_name}-ssm${var.suffix}"
   bucket_policy       = [data.aws_iam_policy_document.bucket_policy.json]
   replication_enabled = false
   versioning_enabled  = true
@@ -152,7 +152,7 @@ data "aws_iam_policy_document" "ssm-admin-policy-doc" {
 }
 
 resource "aws_iam_policy" "ssm-patching-iam-policy" {
-  name        = "ssm-patching-iam-policy"
+  name        = "ssm-patching-iam-policy${var.suffix}"
   description = "IAM Policy for the AWS-PatchAsgInstance automation script that runs as part of the module"
   path        = "/"
   policy      = data.aws_iam_policy_document.ssm-admin-policy-doc.json
@@ -162,7 +162,7 @@ resource "aws_iam_role" "ssm-patching-iam-role" {
   # Ignore this check on tfsec - it causes a fail on resources *. The resource is required for patching purposes
   #tfsec:ignore:aws-iam-no-policy-wildcards
 
-  name = "ssm-patching-iam-role"
+  name = "ssm-patching-iam-role${var.suffix}"
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
     "Statement" : [
@@ -189,7 +189,7 @@ resource "aws_iam_role_policy_attachment" "ssm-admin-automation" {
 ###### ssm maintenance window #####
 
 resource "aws_ssm_maintenance_window" "ssm-maintenance-window" {
-  name     = "${var.application_name}-maintenance-window"
+  name     = "${var.application_name}-maintenance-window${var.suffix}"
   schedule = var.patch_schedule
   duration = 4 # These could be made into variables if required, however 4 hours seems a long enough duration for patching.
   cutoff   = 3
@@ -199,7 +199,7 @@ resource "aws_ssm_maintenance_window" "ssm-maintenance-window" {
 
 resource "aws_ssm_maintenance_window_target" "ssm-maintenance-window-target" {
   window_id     = aws_ssm_maintenance_window.ssm-maintenance-window.id
-  name          = "maintenance-window-target"
+  name          = "maintenance-window-target${var.suffix}"
   description   = "This is a maintenance window target"
   resource_type = "INSTANCE"
 
@@ -212,7 +212,7 @@ resource "aws_ssm_maintenance_window_target" "ssm-maintenance-window-target" {
 ###### ssm automation task #####
 
 resource "aws_ssm_maintenance_window_task" "ssm-maintenance-window-automation-task" {
-  name             = "${var.application_name}-automation-patching-task"
+  name             = "${var.application_name}-automation-patching-task${var.suffix}"
   max_concurrency  = 20
   max_errors       = 10
   priority         = 1
@@ -248,7 +248,7 @@ resource "aws_ssm_maintenance_window_task" "ssm-maintenance-window-automation-ta
 ###### Resource Group  #####
 
 resource "aws_resourcegroups_group" "patch-resource-group" {
-  name = "${var.application_name}-patch-group"
+  name = "${var.application_name}-patch-group${var.suffix}"
   resource_query {
     query = <<JSON
 {
@@ -284,7 +284,7 @@ JSON
 #}
 
 resource "aws_ssm_patch_baseline" "oracle-database-baseline" {
-  name             = "${var.application_name}-baseline"
+  name             = "${var.application_name}-baseline${var.suffix}"
   operating_system = var.operating_system
 
   approval_rule {
@@ -299,7 +299,7 @@ resource "aws_ssm_patch_baseline" "oracle-database-baseline" {
 }
 
 resource "aws_ssm_patch_baseline" "oracle-database-patch-baseline" {
-  name             = "oracle-database-patch-baseline"
+  name             = "oracle-database-patch-baseline${var.suffix}"
   description      = "Patch Baseline Description"
   rejected_patches = var.rejected_patches
 

--- a/variables.tf
+++ b/variables.tf
@@ -60,3 +60,9 @@ variable "rejected_patches" {
   description = "List of patches to be rejected"
   default     = []
 }
+
+variable "suffix" {
+  type        = string
+  description = "Suffix to label resources"
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -64,5 +64,5 @@ variable "rejected_patches" {
 variable "suffix" {
   type        = string
   description = "When creating multiple patch schedules per environment, a suffix can be used to differentiate resources"
-  default     = null
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,6 @@ variable "rejected_patches" {
 
 variable "suffix" {
   type        = string
-  description = "When creating multiple patch schedules per environment, a suffix can be used to differentiate resources "
+  description = "When creating multiple patch schedules per environment, a suffix can be used to differentiate resources"
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,6 @@ variable "rejected_patches" {
 
 variable "suffix" {
   type        = string
-  description = "Suffix to label resources"
+  description = "When creating multiple patch schedules per environment, a suffix can be used to differentiate resources "
   default     = null
 }


### PR DESCRIPTION
This current module only supports one schedule per environment. Attempting to do more will result in errors due to duplicate resource names.

Some use cases for having multiple schedules per environment include targetting instances at different times depending on availability zone and having different schedules per operating system.

This PR addresses this by allowing callers of the module to provide a suffix value to the resource names to prevent duplication.

A test deployment below has been made using this PR, one test calling the module with a suffix and another test without.

https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/9077331502/job/24941987048