### PR TITLE
Removed the s3.* code from the actions in main

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,8 +13,7 @@ data "aws_iam_policy_document" "patch-manager-policy-doc" {
 
     # Ignore this check on tfsec - it causes a fail on resources *. The resource is required for patching purposes
     #tfsec:ignore:aws-iam-no-policy-wildcards
-    actions = ["s3:*",
-      "ec2:*",
+    actions = ["ec2:*",
       "ssm:*",
       "cloudwatch:*",
       "cloudformation:*",


### PR DESCRIPTION
The s3.* was causing issues on some work we were doing. It appears that this is not required anymore so it has been removed from the code in main.tf